### PR TITLE
Handling folderName when refreshing service definition

### DIFF
--- a/.changeset/empty-zebras-sin.md
+++ b/.changeset/empty-zebras-sin.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/generator-asyncapi": patch
+---
+
+fix(plugin): when refreshing service definitions the folder name is taken into consideration

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,7 +229,7 @@ export default async (config: any, options: Props) => {
       if (latestServiceInCatalog.version === version) {
         serviceMarkdown = latestServiceInCatalog.markdown;
         specifications = latestServiceInCatalog.specifications ?? {};
-        await rmService(document.info().title());
+        await rmService(service.folderName || document.info().title());
       }
     }
 

--- a/src/test/plugin.test.ts
+++ b/src/test/plugin.test.ts
@@ -194,6 +194,10 @@ describe('AsyncAPI EventCatalog Plugin', () => {
         await plugin(config, {
           services: [{ path: join(asyncAPIExamplesDir, 'simple.asyncapi.yml'), folderName: 'my-custom-folder' }],
         });
+
+        // Check the file exists in the custom folder name
+        const serviceFile = await fs.readFile(join(catalogDir, 'services', 'my-custom-folder', 'index.md'));
+        expect(serviceFile).toBeDefined();
       });
 
       it('when the AsyncAPI service is already defined in EventCatalog and the versions match, the markdown is persisted and not overwritten', async () => {

--- a/src/test/plugin.test.ts
+++ b/src/test/plugin.test.ts
@@ -176,6 +176,26 @@ describe('AsyncAPI EventCatalog Plugin', () => {
         );
       });
 
+      it('when the AsyncAPI service is already defined in EventCatalog and the versions match, folderName is considered', async () => {
+
+        // Create a service with the same name and version as the AsyncAPI file for testing
+        const { writeService } = utils(catalogDir);
+        const existingVersion = '1.0.0';
+        await writeService(
+          {
+            id: 'account-service',
+            version: existingVersion,
+            name: 'Custom folderName',
+            markdown: 'This service is stored in a folder with custom name',
+            specifications: { openapiPath: 'simple.asyncapi.yml' },
+          },
+          { path: 'my-custom-folder' }
+        );
+
+        await plugin(config, { services: [{ path: join(asyncAPIExamplesDir, 'simple.asyncapi.yml'), folderName: 'my-custom-folder' }] });
+
+      });
+
       it('when the AsyncAPI service is already defined in EventCatalog and the versions match, the markdown is persisted and not overwritten', async () => {
         // Create a service with the same name and version as the AsyncAPI file for testing
         const { writeService, getService } = utils(catalogDir);

--- a/src/test/plugin.test.ts
+++ b/src/test/plugin.test.ts
@@ -177,7 +177,6 @@ describe('AsyncAPI EventCatalog Plugin', () => {
       });
 
       it('when the AsyncAPI service is already defined in EventCatalog and the versions match, folderName is considered', async () => {
-
         // Create a service with the same name and version as the AsyncAPI file for testing
         const { writeService } = utils(catalogDir);
         const existingVersion = '1.0.0';
@@ -192,8 +191,9 @@ describe('AsyncAPI EventCatalog Plugin', () => {
           { path: 'my-custom-folder' }
         );
 
-        await plugin(config, { services: [{ path: join(asyncAPIExamplesDir, 'simple.asyncapi.yml'), folderName: 'my-custom-folder' }] });
-
+        await plugin(config, {
+          services: [{ path: join(asyncAPIExamplesDir, 'simple.asyncapi.yml'), folderName: 'my-custom-folder' }],
+        });
       });
 
       it('when the AsyncAPI service is already defined in EventCatalog and the versions match, the markdown is persisted and not overwritten', async () => {


### PR DESCRIPTION
We added the possibility to specify the `folderName` but is not taken into consideration when updating the service specs. 