### PR TITLE
feat(plugin): persist messages the service receives and sends

### DIFF
--- a/.changeset/wicked-pugs-scream.md
+++ b/.changeset/wicked-pugs-scream.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/generator-asyncapi": patch
+---
+
+feat(plugin): persist messages the service receives and sends

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,8 +102,8 @@ export default async (config: any, options: Props) => {
     const version = document.info().version();
 
     // What messages does this service send and receive
-    const sends = [];
-    const receives = [];
+    let sends = [];
+    let receives = [];
 
     let serviceSpecifications = {};
     let serviceSpecificationsFiles = [];
@@ -235,6 +235,8 @@ export default async (config: any, options: Props) => {
         // we want to preserve the markdown any any spec files that are already there
         serviceMarkdown = latestServiceInCatalog.markdown;
         serviceSpecifications = latestServiceInCatalog.specifications ?? {};
+        sends = latestServiceInCatalog.sends ? [...latestServiceInCatalog.sends, ...sends] : sends;
+        receives = latestServiceInCatalog.receives ? [...latestServiceInCatalog.receives, ...receives] : receives;
         serviceSpecificationsFiles = await getSpecificationFilesForService(serviceId, version);
         await rmService(serviceId);
       }

--- a/src/test/plugin.test.ts
+++ b/src/test/plugin.test.ts
@@ -229,29 +229,78 @@ describe('AsyncAPI EventCatalog Plugin', () => {
         expect(newService).toBeDefined();
       });
 
-      it('any message with the operation `send` is added to the service. The service publishes this message.', async () => {
-        const { getService } = utils(catalogDir);
+      describe('sends', () => {
+        it('any message with the operation `send` is added to the service. The service publishes this message.', async () => {
+          const { getService } = utils(catalogDir);
 
-        await plugin(config, { services: [{ path: join(asyncAPIExamplesDir, 'simple.asyncapi.yml'), id: 'account-service' }] });
+          await plugin(config, { services: [{ path: join(asyncAPIExamplesDir, 'simple.asyncapi.yml'), id: 'account-service' }] });
 
-        const service = await getService('account-service', '1.0.0');
+          const service = await getService('account-service', '1.0.0');
 
-        expect(service.sends).toHaveLength(2);
-        expect(service.sends).toEqual([
-          { id: 'usersignedup', version: '1.0.0' },
-          { id: 'usersignedout', version: '1.0.0' },
-        ]);
+          expect(service.sends).toHaveLength(2);
+          expect(service.sends).toEqual([
+            { id: 'usersignedup', version: '1.0.0' },
+            { id: 'usersignedout', version: '1.0.0' },
+          ]);
+        });
+
+        it('if the service is already defined and is sending messages these are persisted', async () => {
+          const { writeService, getService } = utils(catalogDir);
+
+          await writeService({
+            id: 'account-service',
+            version: '1.0.0',
+            name: 'Account Service',
+            markdown: '',
+            sends: [{ id: 'userloggedin', version: '1.0.0' }],
+          });
+
+          await plugin(config, { services: [{ path: join(asyncAPIExamplesDir, 'simple.asyncapi.yml'), id: 'account-service' }] });
+
+          const service = await getService('account-service', '1.0.0');
+
+          expect(service.sends).toHaveLength(3);
+          expect(service.sends).toEqual([
+            { id: 'userloggedin', version: '1.0.0' },
+            { id: 'usersignedup', version: '1.0.0' },
+            { id: 'usersignedout', version: '1.0.0' },
+          ]);
+        });
       });
 
-      it('any message with the operation `receive` is added to the service. The service receives this message.', async () => {
-        const { getService } = utils(catalogDir);
+      describe('receives', () => {
+        it('any message with the operation `receive` is added to the service. The service receives this message.', async () => {
+          const { getService } = utils(catalogDir);
 
-        await plugin(config, { services: [{ path: join(asyncAPIExamplesDir, 'simple.asyncapi.yml'), id: 'account-service' }] });
+          await plugin(config, { services: [{ path: join(asyncAPIExamplesDir, 'simple.asyncapi.yml'), id: 'account-service' }] });
 
-        const service = await getService('account-service', '1.0.0');
+          const service = await getService('account-service', '1.0.0');
 
-        expect(service.receives).toHaveLength(1);
-        expect(service.receives).toEqual([{ id: 'signupuser', version: '1.0.0' }]);
+          expect(service.receives).toHaveLength(1);
+          expect(service.receives).toEqual([{ id: 'signupuser', version: '1.0.0' }]);
+        });
+
+        it('if the service is already defined and is receiving messages these are persisted', async () => {
+          const { writeService, getService } = utils(catalogDir);
+
+          await writeService({
+            id: 'account-service',
+            version: '1.0.0',
+            name: 'Account Service',
+            markdown: '',
+            receives: [{ id: 'userloggedin', version: '1.0.0' }],
+          });
+
+          await plugin(config, { services: [{ path: join(asyncAPIExamplesDir, 'simple.asyncapi.yml'), id: 'account-service' }] });
+
+          const service = await getService('account-service', '1.0.0');
+
+          expect(service.receives).toHaveLength(2);
+          expect(service.receives).toEqual([
+            { id: 'userloggedin', version: '1.0.0' },
+            { id: 'signupuser', version: '1.0.0' },
+          ]);
+        });
       });
 
       it('the asyncapi file is added to the service which can be downloaded in eventcatalog', async () => {


### PR DESCRIPTION
People can use generators together, the generator does not own the sends and recieves of the service, but adds to it.

This fix will make sure this generator will add to the messages of the service if the service is already defined by other generators.