### PR TITLE
fix(plugin): throw explicit error message on service id not provided

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,17 @@ type Props = {
   saveParsedSpecFile?: boolean;
 };
 
+const validateOptions = (options: Props) => {
+  if (!options.services) {
+    throw new Error('Please provide correct services configuration');
+  }
+  if (options.services.some((service) => !service.id)) {
+    throw new Error('The service id is required. please provide a service id');
+  }
+  if (options.services.some((service) => !service.path)) {
+    throw new Error('The service path is required. please provide the path to specification file');
+  }
+};
 export default async (config: any, options: Props) => {
   if (!process.env.PROJECT_DIR) {
     throw new Error('Please provide catalog url (env variable PROJECT_DIR)');
@@ -76,9 +87,9 @@ export default async (config: any, options: Props) => {
 
   // Should the file that is written to the catalog be parsed (https://github.com/asyncapi/parser-js) or as it is?
   const { services, saveParsedSpecFile = false } = options;
+  validateOptions(options);
   // const asyncAPIFiles = Array.isArray(options.path) ? options.path : [options.path];
   console.log(chalk.green(`Processing ${services.length} AsyncAPI files...`));
-
   for (const service of services) {
     console.log(chalk.gray(`Processing ${service.path}`));
 
@@ -98,6 +109,7 @@ export default async (config: any, options: Props) => {
     const documentTags = document.info().tags().all() || [];
 
     const serviceId = service.id;
+
     const serviceName = service.name || document.info().title();
     const version = document.info().version();
 

--- a/src/test/plugin.test.ts
+++ b/src/test/plugin.test.ts
@@ -3,6 +3,7 @@ import utils from '@eventcatalog/sdk';
 import plugin from '../index';
 import { join } from 'node:path';
 import fs from 'fs/promises';
+import { existsSync } from 'fs';
 
 // Fake eventcatalog config
 const config = {};
@@ -18,7 +19,7 @@ describe('AsyncAPI EventCatalog Plugin', () => {
     });
 
     afterEach(async () => {
-      await fs.rm(join(catalogDir), { recursive: true });
+      if (existsSync(catalogDir)) await fs.rm(join(catalogDir), { recursive: true });
     });
 
     describe('domains', () => {
@@ -516,8 +517,8 @@ describe('AsyncAPI EventCatalog Plugin', () => {
             expect(service).toBeDefined();
           });
         });
-        describe('config option: name', () => {
-          it('if the `name` value is given in the service config options, then the service name is set to the config value', async () => {
+        describe('config options', () => {
+          it('[name] if the `name` value is given in the service config options, then the service name is set to the config value', async () => {
             const { getService } = utils(catalogDir);
 
             await plugin(config, {
@@ -532,6 +533,34 @@ describe('AsyncAPI EventCatalog Plugin', () => {
 
             const service = await getService('account-service', '1.0.0');
             expect(service.name).toEqual('Awesome account service');
+          });
+
+          it('[id] if the `id` not provided in the service config options, The generator throw an explicit error', async () => {
+            await expect(
+              plugin(config, {
+                services: [
+                  {
+                    path: join(asyncAPIExamplesDir, 'simple.asyncapi.yml'),
+                    name: 'Awesome account service',
+                  } as any,
+                ],
+              })
+            ).rejects.toThrow('The service id is required');
+          });
+          it('[services] if the `services` not provided in options, The generator throw an explicit error', async () => {
+            await expect(plugin(config, {} as any)).rejects.toThrow('Please provide correct services configuration');
+          });
+          it('[path] if the `path` not provided in service config options, The generator throw an explicit error', async () => {
+            await expect(
+              plugin(config, {
+                services: [
+                  {
+                    name: 'Awesome account service',
+                    id: 'awsome-service',
+                  } as any,
+                ],
+              })
+            ).rejects.toThrow('The service path is required. please provide the path to specification file');
           });
         });
       });


### PR DESCRIPTION
Motivation
The fix resolve the technical exception while the consumers forget to add the mandatory service id while upgrading to version 2.0.0