### PR TITLE
Rfc/message visibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,17 @@ type Props = {
   saveParsedSpecFile?: boolean;
 };
 
+const validateOptions = (options: Props) => {
+  if (!options.services) {
+    throw new Error('Please provide correct services configuration');
+  }
+  if (options.services.some((service) => !service.id)) {
+    throw new Error('The service id is required. please provide a service id');
+  }
+  if (options.services.some((service) => !service.path)) {
+    throw new Error('The service path is required. please provide the path to specification file');
+  }
+};
 export default async (config: any, options: Props) => {
   if (!process.env.PROJECT_DIR) {
     throw new Error('Please provide catalog url (env variable PROJECT_DIR)');
@@ -76,9 +87,9 @@ export default async (config: any, options: Props) => {
 
   // Should the file that is written to the catalog be parsed (https://github.com/asyncapi/parser-js) or as it is?
   const { services, saveParsedSpecFile = false } = options;
+  validateOptions(options);
   // const asyncAPIFiles = Array.isArray(options.path) ? options.path : [options.path];
   console.log(chalk.green(`Processing ${services.length} AsyncAPI files...`));
-
   for (const service of services) {
     console.log(chalk.gray(`Processing ${service.path}`));
 
@@ -98,6 +109,7 @@ export default async (config: any, options: Props) => {
     const documentTags = document.info().tags().all() || [];
 
     const serviceId = service.id;
+
     const serviceName = service.name || document.info().title();
     const version = document.info().version();
 

--- a/src/test/asyncapi-files/simple.asyncapi.yml
+++ b/src/test/asyncapi-files/simple.asyncapi.yml
@@ -25,6 +25,11 @@ channels:
         $ref: '#/components/messages/SignUpUser'
       UserSignedOut:
         $ref: '#/components/messages/UserSignedOut'
+  userSubscription:
+    address: user/subscription
+    messages:
+      UserSubscribed:
+        $ref: '#/components/messages/UserSubscribed'
 operations:
   sendUserSignedup:
     action: send
@@ -44,6 +49,12 @@ operations:
       $ref: '#/channels/userSignedup'
     messages:
       - $ref: '#/channels/userSignedup/messages/UserSignedOut'
+  onUserSubscribed:
+    action: receive
+    channel:
+      $ref: '#/channels/userSubscription'
+    messages:
+      - $ref: '#/channels/userSubscription/messages/UserSubscribed'
 components:
   messages:
     UserSignedUp:
@@ -100,3 +111,15 @@ components:
             type: string
             format: email
             description: Email of the user
+    UserSubscribed:
+      description: 'User Subscribed to newsletters'
+      x-eventcatalog-visibility: external
+      tags:
+        - name: 'New'
+          description: 'New event'
+      payload:
+        type: object
+        properties:
+          email:
+            type: string
+            description: email of the user

--- a/src/test/plugin.test.ts
+++ b/src/test/plugin.test.ts
@@ -251,8 +251,11 @@ describe('AsyncAPI EventCatalog Plugin', () => {
 
         const service = await getService('account-service', '1.0.0');
 
-        expect(service.receives).toHaveLength(1);
-        expect(service.receives).toEqual([{ id: 'signupuser', version: '1.0.0' }]);
+        expect(service.receives).toHaveLength(2);
+        expect(service.receives).toEqual([
+          { id: 'signupuser', version: '1.0.0' },
+          { id: 'usersubscribed', version: '1.0.0' },
+        ]);
       });
 
       it('the asyncapi file is added to the service which can be downloaded in eventcatalog', async () => {
@@ -585,7 +588,7 @@ describe('AsyncAPI EventCatalog Plugin', () => {
         expect(newEvent).toBeDefined();
       });
 
-      it('when a the message already exists in EventCatalog the markdown is persisted and not overwritten', async () => {
+      it('when a message already exists in EventCatalog the markdown is persisted and not overwritten', async () => {
         const { writeEvent, getEvent } = utils(catalogDir);
 
         await writeEvent({
@@ -615,6 +618,18 @@ describe('AsyncAPI EventCatalog Plugin', () => {
 
         const newEvent = await getEvent('usersignedup', '1.0.0');
         expect(newEvent.markdown).toEqual('please dont override me!');
+      });
+
+      it('any message with the operation `receive` and using the custom `ec-external-message` does not create new or modify existing message.', async () => {
+        const { getEvent } = utils(catalogDir);
+        const { getService } = utils(catalogDir);
+
+        await plugin(config, { services: [{ path: join(asyncAPIExamplesDir, 'simple.asyncapi.yml'), id: 'account-service' }] });
+
+        const service = await getService('account-service', '1.0.0');
+        const newEvent = await getEvent('usersubscribed', 'latest');
+        expect(newEvent).toBeUndefined();
+        expect(service.receives).toHaveLength(2);
       });
 
       describe('schemas', () => {


### PR DESCRIPTION
Motivation
When integrating multiple specs some services are event producers some event consumers , some send commands some receive commands.

Given the above explanation, in reality, a command contract is owned by the receiving service but sent by the upstream service, in the other side an event contract is owned by the producer service but received by the downstream service.

When integrating multiple specs, if the generator finds a received event already created by the event owner spec, it will overwrite it. If that event version is already versioned (not latest ) by owner service, the SDK throws an error.

Service A > Sends Event A1 > Sends  EventA2
Service B > Receives Event A1
The variety of situations makes it hard to find a convention to automate only based on asyncapi spec.

The PR introduces a declarative way to skip external message creation or modifications using asyncapi extensions x-eventcatalog-visibility.