### PR TITLE
feat([asyncapi]): if service version is lower than latest add a servi…

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/lodash": "^4.17.7",
     "@types/minimist": "^1.2.5",
     "@types/node": "^20.16.1",
+    "@types/semver": "^7.5.8",
     "prettier": "^3.3.3",
     "tsup": "^8.1.0",
     "typescript": "^5.5.3",
@@ -46,6 +47,7 @@
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
     "minimist": "^1.2.8",
+    "semver": "^7.6.3",
     "slugify": "^1.6.6",
     "zod": "^3.23.8"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       minimist:
         specifier: ^1.2.8
         version: 1.2.8
+      semver:
+        specifier: ^7.6.3
+        version: 7.6.3
       slugify:
         specifier: ^1.6.6
         version: 1.6.6
@@ -63,6 +66,9 @@ importers:
       '@types/node':
         specifier: ^20.16.1
         version: 20.16.9
+      '@types/semver':
+        specifier: ^7.5.8
+        version: 7.5.8
       prettier:
         specifier: ^3.3.3
         version: 3.3.3
@@ -675,6 +681,9 @@ packages:
 
   '@types/node@20.16.9':
     resolution: {integrity: sha512-rkvIVJxsOfBejxK7I0FO5sa2WxFmJCzoDwcd88+fq/CUfynNywTo/1/T6hyFz22CyztsnLS9nVlHOnTI36RH5w==}
+
+  '@types/semver@7.5.8':
+    resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
 
   '@types/urijs@1.19.25':
     resolution: {integrity: sha512-XOfUup9r3Y06nFAZh3WvO0rBU4OtlfPB/vgxpjg+NRdGU6CN6djdc6OEiH+PcqHCY6eFLo9Ista73uarf4gnBg==}
@@ -2613,6 +2622,8 @@ snapshots:
   '@types/node@20.16.9':
     dependencies:
       undici-types: 6.19.8
+
+  '@types/semver@7.5.8': {}
 
   '@types/urijs@1.19.25': {}
 


### PR DESCRIPTION
## Motivation
When service version lower than latest are treated after latest is already treated this leads to versioning the latest in versioned and keep the incorrect version as latest.

example:
if a spec for version 2 is treated and later version 1 is treated the latest version will be the v1 and v2 get into the versions folder.

This pull request checks the sequence of versions and treats them in the correct order