### PR TITLE
feat(plugin): added support for queries in messages

### DIFF
--- a/.changeset/strong-points-sell.md
+++ b/.changeset/strong-points-sell.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/generator-asyncapi": patch
+---
+
+feat(plugin): added support for queries in messages

--- a/src/test/asyncapi-files/simple.asyncapi.yml
+++ b/src/test/asyncapi-files/simple.asyncapi.yml
@@ -25,6 +25,10 @@ channels:
         $ref: '#/components/messages/SignUpUser'
       UserSignedOut:
         $ref: '#/components/messages/UserSignedOut'
+      GetUserByEmail:
+        $ref: '#/components/messages/GetUserByEmail'
+      CheckEmailAvailability:
+        $ref: '#/components/messages/CheckEmailAvailability'
 operations:
   sendUserSignedup:
     action: send
@@ -44,6 +48,18 @@ operations:
       $ref: '#/channels/userSignedup'
     messages:
       - $ref: '#/channels/userSignedup/messages/UserSignedOut'
+  getUserByEmail:
+    action: receive
+    channel:
+      $ref: '#/channels/userSignedup'
+    messages:
+      - $ref: '#/channels/userSignedup/messages/GetUserByEmail'
+  checkEmailAvailability:
+    action: receive
+    channel:
+      $ref: '#/channels/userSignedup'
+    messages:
+      - $ref: '#/channels/userSignedup/messages/CheckEmailAvailability'
 components:
   messages:
     UserSignedUp:
@@ -100,3 +116,29 @@ components:
             type: string
             format: email
             description: Email of the user
+    GetUserByEmail:
+      description: 'Get user information by email'
+      x-eventcatalog-message-type: query
+      tags:
+        - name: 'Query'
+          description: 'Query message'
+      payload:
+        type: object
+        properties:
+          email:
+            type: string
+            format: email
+            description: Email of the user to retrieve
+    CheckEmailAvailability:
+      description: 'Check if an email is available for registration'
+      x-eventcatalog-message-type: query
+      tags:
+        - name: 'Query'
+          description: 'Query message'
+      payload:
+        type: object
+        properties:
+          email:
+            type: string
+            format: email
+            description: Email to check for availability

--- a/src/test/plugin.test.ts
+++ b/src/test/plugin.test.ts
@@ -301,8 +301,18 @@ describe('AsyncAPI EventCatalog Plugin', () => {
 
           const service = await getService('account-service', '1.0.0');
 
-          expect(service.receives).toHaveLength(1);
-          expect(service.receives).toEqual([{ id: 'signupuser', version: '1.0.0' }]);
+          expect(service.receives).toHaveLength(3);
+          expect(service.receives).toEqual([
+            { id: 'signupuser', version: '1.0.0' },
+            {
+              id: 'getuserbyemail',
+              version: '1.0.0',
+            },
+            {
+              id: 'checkemailavailability',
+              version: '1.0.0',
+            },
+          ]);
         });
 
         it('if the service is already defined and is receiving messages these are persisted', async () => {
@@ -320,10 +330,14 @@ describe('AsyncAPI EventCatalog Plugin', () => {
 
           const service = await getService('account-service', '1.0.0');
 
-          expect(service.receives).toHaveLength(2);
+          console.log(JSON.stringify(service.receives, null, 2));
+
+          expect(service.receives).toHaveLength(4);
           expect(service.receives).toEqual([
             { id: 'userloggedin', version: '1.0.0' },
             { id: 'signupuser', version: '1.0.0' },
+            { id: 'getuserbyemail', version: '1.0.0' },
+            { id: 'checkemailavailability', version: '1.0.0' },
           ]);
         });
       });
@@ -679,6 +693,33 @@ describe('AsyncAPI EventCatalog Plugin', () => {
                 backgroundColor: 'blue',
               },
             ],
+          })
+        );
+      });
+
+      it('messages marked as "queries" using the custom `ec-message-type` header in an AsyncAPI are documented in EventCatalog as queries ', async () => {
+        const { getQuery } = utils(catalogDir);
+
+        await plugin(config, { services: [{ path: join(asyncAPIExamplesDir, 'simple.asyncapi.yml'), id: 'account-service' }] });
+
+        const query = await getQuery('checkemailavailability');
+
+        console.log(JSON.stringify(query, null, 2));
+
+        expect(query).toEqual(
+          expect.objectContaining({
+            id: 'checkemailavailability',
+            version: '1.0.0',
+            name: 'CheckEmailAvailability',
+            summary: 'Check if an email is available for registration',
+            badges: [
+              {
+                content: 'Query',
+                textColor: 'blue',
+                backgroundColor: 'blue',
+              },
+            ],
+            schemaPath: 'schema.json',
           })
         );
       });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,11 @@
+// Define the types of operations available for each message type
+export interface MessageOperations {
+  write: (payload: any, options: any) => Promise<void>;
+  version: (id: string) => Promise<any>;
+  get: (id: string, version: string) => Promise<any>;
+  remove: (id: string, version: string) => Promise<void>;
+  addSchema: (id: string, schema: any, version: any) => Promise<void>;
+}
+
+// Define valid event types
+export type EventType = 'event' | 'command' | 'query';


### PR DESCRIPTION
any messages marked with `x-eventcatalog-message-type: query` will now be processed as queries in EventCatalog.