### PR TITLE
fix(plugin): the original schema is now stored against the message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -256,11 +256,14 @@ export default async (config: any, options: Props) => {
           console.log(chalk.cyan(` - Message (v${messageVersion}) created`));
           // Check if the message has a payload, if it does then document in EventCatalog
           if (messageHasSchema(message)) {
+            // Get the schema from the original payload if it exists
+            const schema = message.payload()?.extensions()?.get('x-parser-original-payload')?.json() || message.payload()?.json();
+
             addSchemaToMessage(
               messageId,
               {
                 fileName: getSchemaFileName(message),
-                schema: JSON.stringify(message.payload()?.json(), null, 4),
+                schema: JSON.stringify(schema, null, 4),
               },
               messageVersion
             );

--- a/src/test/plugin.test.ts
+++ b/src/test/plugin.test.ts
@@ -830,6 +830,8 @@ describe('AsyncAPI EventCatalog Plugin', () => {
           await plugin(config, { services: [{ path: join(asyncAPIExamplesDir, 'simple.asyncapi.yml'), id: 'account-service' }] });
 
           const schema = await fs.readFile(join(catalogDir, 'events', 'UserSignedUp', 'schema.json'));
+
+          console.log('SCHEMA', schema.toString());
           expect(schema).toBeDefined();
         });
 
@@ -877,7 +879,7 @@ describe('AsyncAPI EventCatalog Plugin', () => {
     });
 
     describe('asyncapi files with avro schemas', () => {
-      it('parses the AsyncAPI file with avro schemas', async () => {
+      it('parses the AsyncAPI file with avro schemas, and stores the avro schema against the event', async () => {
         const { getEvent, getService } = utils(catalogDir);
 
         await plugin(config, {
@@ -893,8 +895,24 @@ describe('AsyncAPI EventCatalog Plugin', () => {
         expect(event.schemaPath).toEqual('schema.avsc');
 
         // Check file schema.avsc
-        const schema = await fs.readFile(join(catalogDir, 'events', 'userSignedUp', 'schema.avsc'));
-        expect(schema).toBeDefined();
+        const schema = await fs.readFile(join(catalogDir, 'events', 'userSignedUp', 'schema.avsc'), 'utf-8');
+        const schemaParsed = JSON.parse(schema);
+        expect(schemaParsed).toEqual({
+          type: 'record',
+          name: 'UserSignedUp',
+          namespace: 'com.company',
+          doc: 'User sign-up information',
+          fields: [
+            {
+              name: 'userId',
+              type: 'int',
+            },
+            {
+              name: 'userEmail',
+              type: 'string',
+            },
+          ],
+        });
       });
     });
 


### PR DESCRIPTION
There was a problem when saving the schemas against the message. The schema that was stored was the parsed schema, the AsyncAPI parser would add additional properties and things onto the schema that was stored in EventCatalog. Example would be avro schemas seen in this example repo https://github.com/HansMartinJ/eventcatalog-sample-schema-generation-bug

This fix checks to see if the original messages is there, and should be used, otherwise default back to what was happening.