### PR TITLE
feat(plugin): added optional field to not parse schemas when parsing …

### DIFF
--- a/.changeset/little-bulldogs-lick.md
+++ b/.changeset/little-bulldogs-lick.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/generator-asyncapi": patch
+---
+
+feat(plugin): added optional field to not parse schemas when parsing …

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,6 @@ export default async (config: any, options: Props) => {
   // Should the file that is written to the catalog be parsed (https://github.com/asyncapi/parser-js) or as it is?
   validateOptions(options);
   const { services, saveParsedSpecFile = false, parseSchemas = true } = options;
-  console.log('parseSchemas', parseSchemas);
   // const asyncAPIFiles = Array.isArray(options.path) ? options.path : [options.path];
   console.log(chalk.green(`Processing ${services.length} AsyncAPI files...`));
   for (const service of services) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ const optionsSchema = z.object({
     })
     .optional(),
   debug: z.boolean().optional(),
+  parseSchemas: z.boolean().optional(),
   saveParsedSpecFile: z.boolean({ invalid_type_error: 'The saveParsedSpecFile is not a boolean in options' }).optional(),
 });
 
@@ -120,15 +121,20 @@ export default async (config: any, options: Props) => {
 
   // Should the file that is written to the catalog be parsed (https://github.com/asyncapi/parser-js) or as it is?
   validateOptions(options);
-  const { services, saveParsedSpecFile = false } = options;
+  const { services, saveParsedSpecFile = false, parseSchemas = true } = options;
+  console.log('parseSchemas', parseSchemas)
   // const asyncAPIFiles = Array.isArray(options.path) ? options.path : [options.path];
   console.log(chalk.green(`Processing ${services.length} AsyncAPI files...`));
   for (const service of services) {
     console.log(chalk.gray(`Processing ${service.path}`));
 
     const { document, diagnostics } = service.path.startsWith('http')
-      ? await fromURL(parser, service.path).parse()
-      : await fromFile(parser, service.path).parse();
+      ? await fromURL(parser, service.path).parse({
+          parseSchemas,
+        })
+      : await fromFile(parser, service.path).parse({
+          parseSchemas,
+        });
 
     if (!document) {
       console.log(chalk.red('Failed to parse AsyncAPI file'));

--- a/src/index.ts
+++ b/src/index.ts
@@ -264,7 +264,7 @@ export default async (config: any, options: Props) => {
             // Get the schema from the original payload if it exists
             const schema = message.payload()?.extensions()?.get('x-parser-original-payload')?.json() || message.payload()?.json();
 
-            addSchemaToMessage(
+            await addSchemaToMessage(
               messageId,
               {
                 fileName: getSchemaFileName(message),

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,7 @@ export default async (config: any, options: Props) => {
   // Should the file that is written to the catalog be parsed (https://github.com/asyncapi/parser-js) or as it is?
   validateOptions(options);
   const { services, saveParsedSpecFile = false, parseSchemas = true } = options;
-  console.log('parseSchemas', parseSchemas)
+  console.log('parseSchemas', parseSchemas);
   // const asyncAPIFiles = Array.isArray(options.path) ? options.path : [options.path];
   console.log(chalk.green(`Processing ${services.length} AsyncAPI files...`));
   for (const service of services) {

--- a/src/test/asyncapi-files/asyncapi-with-avro-expect-not-to-parse-schemas-example-schema.avro
+++ b/src/test/asyncapi-files/asyncapi-with-avro-expect-not-to-parse-schemas-example-schema.avro
@@ -1,0 +1,29 @@
+
+{
+  "type": "record",
+  "name": "UserCreated",
+  "namespace": "com.example.events",
+  "fields": [
+    {
+      "name": "id",
+      "type": "string",
+      "doc": "User identifier"
+    },
+    {
+      "name": "email",
+      "type": "string",
+      "doc": "User's email address"
+    },
+    {
+      "name": "createdAt",
+      "type": "long",
+      "doc": "Timestamp of user creation",
+      "logicalType": "timestamp-millis"
+    },
+    {
+      "name": "isActive",
+      "type": "boolean",
+      "default": true
+    }
+  ]
+}

--- a/src/test/asyncapi-files/asyncapi-with-avro-expect-not-to-parse-schemas.yml
+++ b/src/test/asyncapi-files/asyncapi-with-avro-expect-not-to-parse-schemas.yml
@@ -1,0 +1,30 @@
+asyncapi: 3.0.0
+info:
+  title: Streetlights App
+  version: '1.0.0'
+  description: |
+    The Smartylighting Streetlights application allows you
+    to remotely manage the city lights.
+  license:
+    name: Apache 2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0'
+servers:
+  mosquitto:
+    host: test.mosquitto.org
+    protocol: mqtt
+channels:
+  lightMeasuredAvro:
+    address: 'light/measuredavro'
+    messages:
+      lightMeasuredMessageAvro:
+        name: LightMeasuredAvro
+        payload:
+          schemaFormat: 'application/vnd.apache.avro;version=1.9.0'
+          schema:
+            $ref: "./asyncapi-with-avro-expect-not-to-parse-schemas-example-schema.avro"
+operations:
+  receiveAvro:
+    action: 'receive'
+    summary: Information about environmental lighting conditions for a particular streetlight.
+    channel:
+      $ref: '#/channels/lightMeasuredAvro'

--- a/src/test/asyncapi-files/asyncapi-with-avro-expect-not-to-parse-schemas.yml
+++ b/src/test/asyncapi-files/asyncapi-with-avro-expect-not-to-parse-schemas.yml
@@ -21,7 +21,7 @@ channels:
         payload:
           schemaFormat: 'application/vnd.apache.avro;version=1.9.0'
           schema:
-            $ref: "./asyncapi-with-avro-expect-not-to-parse-schemas-example-schema.avro"
+            $ref: './asyncapi-with-avro-expect-not-to-parse-schemas-example-schema.avro'
 operations:
   receiveAvro:
     action: 'receive'

--- a/src/test/plugin.test.ts
+++ b/src/test/plugin.test.ts
@@ -331,8 +331,6 @@ describe('AsyncAPI EventCatalog Plugin', () => {
 
           const service = await getService('account-service', '1.0.0');
 
-          console.log(JSON.stringify(service.receives, null, 2));
-
           expect(service.receives).toHaveLength(5);
           expect(service.receives).toEqual([
             { id: 'userloggedin', version: '1.0.0' },
@@ -706,8 +704,6 @@ describe('AsyncAPI EventCatalog Plugin', () => {
 
         const query = await getQuery('checkemailavailability');
 
-        console.log(JSON.stringify(query, null, 2));
-
         expect(query).toEqual(
           expect.objectContaining({
             id: 'checkemailavailability',
@@ -831,7 +827,6 @@ describe('AsyncAPI EventCatalog Plugin', () => {
 
           const schema = await fs.readFile(join(catalogDir, 'events', 'UserSignedUp', 'schema.json'));
 
-          console.log('SCHEMA', schema.toString());
           expect(schema).toBeDefined();
         });
 

--- a/src/test/plugin.test.ts
+++ b/src/test/plugin.test.ts
@@ -855,7 +855,7 @@ describe('AsyncAPI EventCatalog Plugin', () => {
         expect(event.schemaPath).toEqual('schema.json');
       });
 
-      it.only('if `parseSchemas` is false, the schemas for the AsyncAPI document are not parsed, and the original AsyncAPI file is saved against the service', async () => {
+      it('if `parseSchemas` is false, the schemas for the AsyncAPI document are not parsed, and the original AsyncAPI file is saved against the service', async () => {
         const { getEvent, getService } = utils(catalogDir);
 
         await plugin(config, {
@@ -874,7 +874,7 @@ describe('AsyncAPI EventCatalog Plugin', () => {
         expect(event.schemaPath).toEqual('schema.avsc');
 
         const files = await fs.readdir(join(catalogDir, 'events', 'lightmeasuredmessageavro'));
-        console.log('FILES', files);
+        console.log('FILES111', files);
 
         const schema = await fs.readFile(join(catalogDir, 'events', 'lightmeasuredmessageavro', 'schema.avsc'), 'utf-8');
         const parsedAsyncAPIFile = await fs.readFile(

--- a/src/test/plugin.test.ts
+++ b/src/test/plugin.test.ts
@@ -855,7 +855,7 @@ describe('AsyncAPI EventCatalog Plugin', () => {
         expect(event.schemaPath).toEqual('schema.json');
       });
 
-      it.only('if `parseSchemas` is false, the schemas for the AsyncAPI document are not parsed, and the original AsyncAPI file is saved against the service', async () => {
+      it('if `parseSchemas` is false, the schemas for the AsyncAPI document are not parsed, and the original AsyncAPI file is saved against the service', async () => {
         const { getEvent, getService } = utils(catalogDir);
 
         await plugin(config, {

--- a/src/test/plugin.test.ts
+++ b/src/test/plugin.test.ts
@@ -855,7 +855,7 @@ describe('AsyncAPI EventCatalog Plugin', () => {
         expect(event.schemaPath).toEqual('schema.json');
       });
 
-      it('if `parseSchemas` is false, the schemas for the AsyncAPI document are not parsed, and the original AsyncAPI file is saved against the service', async () => {
+      it.only('if `parseSchemas` is false, the schemas for the AsyncAPI document are not parsed, and the original AsyncAPI file is saved against the service', async () => {
         const { getEvent, getService } = utils(catalogDir);
 
         await plugin(config, {

--- a/src/test/plugin.test.ts
+++ b/src/test/plugin.test.ts
@@ -855,7 +855,7 @@ describe('AsyncAPI EventCatalog Plugin', () => {
         expect(event.schemaPath).toEqual('schema.json');
       });
 
-      it('if `parseSchemas` is false, the schemas for the AsyncAPI document are not parsed, and the original AsyncAPI file is saved against the service', async () => {
+      it.only('if `parseSchemas` is false, the schemas for the AsyncAPI document are not parsed, and the original AsyncAPI file is saved against the service', async () => {
         const { getEvent, getService } = utils(catalogDir);
 
         await plugin(config, {
@@ -874,7 +874,7 @@ describe('AsyncAPI EventCatalog Plugin', () => {
         expect(event.schemaPath).toEqual('schema.avsc');
 
         const files = await fs.readdir(join(catalogDir, 'events', 'lightmeasuredmessageavro'));
-        console.log(files);
+        console.log('FILES', files);
 
         const schema = await fs.readFile(join(catalogDir, 'events', 'lightmeasuredmessageavro', 'schema.avsc'), 'utf-8');
         const parsedAsyncAPIFile = await fs.readFile(

--- a/src/test/plugin.test.ts
+++ b/src/test/plugin.test.ts
@@ -873,6 +873,9 @@ describe('AsyncAPI EventCatalog Plugin', () => {
         expect(event).toBeDefined();
         expect(event.schemaPath).toEqual('schema.avsc');
 
+        const files = await fs.readdir(join(catalogDir, 'events', 'lightmeasuredmessageavro'));
+        console.log(files);
+
         const schema = await fs.readFile(join(catalogDir, 'events', 'lightmeasuredmessageavro', 'schema.avsc'), 'utf-8');
         const parsedAsyncAPIFile = await fs.readFile(
           join(catalogDir, 'services', 'test-service', 'asyncapi-with-avro-expect-not-to-parse-schemas.yml'),

--- a/src/test/plugin.test.ts
+++ b/src/test/plugin.test.ts
@@ -873,10 +873,7 @@ describe('AsyncAPI EventCatalog Plugin', () => {
         expect(event).toBeDefined();
         expect(event.schemaPath).toEqual('schema.avsc');
 
-        const files = await fs.readdir(join(catalogDir, 'events', 'lightmeasuredmessageavro'));
-        console.log('FILES111', files);
-
-        const schema = await fs.readFile(join(catalogDir, 'events', 'lightmeasuredmessageavro', 'schema.avsc'), 'utf-8');
+        const schema = await fs.readFile(join(catalogDir, 'events', 'lightMeasuredMessageAvro', 'schema.avsc'), 'utf-8');
         const parsedAsyncAPIFile = await fs.readFile(
           join(catalogDir, 'services', 'test-service', 'asyncapi-with-avro-expect-not-to-parse-schemas.yml'),
           'utf-8'


### PR DESCRIPTION
The generator will parse your AsyncAPI files, part of this process the schemas for your messages are also parsed.

This PR adds a new field `parseSchemas`

true (default): The parser will:

Validate schemas (JSON Schema, Avro, etc.)
Convert non-JSON Schema formats into JSON Schema
Add parser metadata (x-parser-schema-id, etc.)


false: The parser will:

Skip schema validation
Keep original schema formats unchanged
Not add any schema-related metadata