### PR TITLE
fix([asycnapiu-v2]): sends/received messages are collected correctly

### DIFF
--- a/.changeset/stupid-berries-repair.md
+++ b/.changeset/stupid-berries-repair.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/generator-asyncapi": minor
+---
+
+fix(plugin): added support for AsyncAPI v2 files, pub/sub messages now matched correctly

--- a/src/index.ts
+++ b/src/index.ts
@@ -204,7 +204,7 @@ export default async (config: any, options: Props) => {
 
         // does this service own or just consume the message?
         const serviceOwnsMessageContract = isServiceMessageOwner(message);
-        const isReceived = operation.action() === 'receive' || operation.action() === 'receive';
+        const isReceived = operation.action() === 'receive' || operation.action() === 'subscribe';
         const isSent = operation.action() === 'send' || operation.action() === 'publish';
 
         const messageId = message.id().toLowerCase();

--- a/src/test/asyncapi-files/simple.asyncapi-v2.yml
+++ b/src/test/asyncapi-files/simple.asyncapi-v2.yml
@@ -1,0 +1,21 @@
+asyncapi: 2.6.0
+info:
+  title: Account Service
+  version: 1.0.0
+
+channels:
+  chat:
+    publish:
+      operationId: messagePublished
+      message:
+        messageId: SomeCoolpublishedMessage
+        name: text
+        payload:
+          type: string
+    subscribe:
+      operationId: receiveMessage
+      message:
+        messageId: SomeCoolReceivedMessage
+        name: text
+        payload:
+          type: string

--- a/src/test/plugin.test.ts
+++ b/src/test/plugin.test.ts
@@ -267,6 +267,7 @@ describe('AsyncAPI EventCatalog Plugin', () => {
             { id: 'usersignedout', version: '1.0.0' },
           ]);
         });
+
         it('if the service is already defined and is sending messages these are persisted, messages are not duplicated in the list', async () => {
           const { writeService, getService } = utils(catalogDir);
 
@@ -291,6 +292,19 @@ describe('AsyncAPI EventCatalog Plugin', () => {
             { id: 'usersignedout', version: '1.0.0' },
           ]);
         });
+
+        it('[AsyncApi 2.X] any message with the operation `publish` is added to the service. The service sends this message.', async () => {
+          const { getService } = utils(catalogDir);
+
+          await plugin(config, {
+            services: [{ path: join(asyncAPIExamplesDir, 'simple.asyncapi-v2.yml'), id: 'account-service' }],
+          });
+
+          const service = await getService('account-service', '1.0.0');
+
+          expect(service.sends).toHaveLength(1);
+          expect(service.sends).toEqual([{ id: 'somecoolpublishedmessage', version: '1.0.0' }]);
+        });
       });
 
       describe('receives', () => {
@@ -314,6 +328,19 @@ describe('AsyncAPI EventCatalog Plugin', () => {
             },
             { id: 'usersubscribed', version: '1.0.0' },
           ]);
+        });
+
+        it('[AsyncApi 2.X] any message with the operation `subscribe` is added to the service. The service receives this message.', async () => {
+          const { getService } = utils(catalogDir);
+
+          await plugin(config, {
+            services: [{ path: join(asyncAPIExamplesDir, 'simple.asyncapi-v2.yml'), id: 'account-service' }],
+          });
+
+          const service = await getService('account-service', '1.0.0');
+
+          expect(service.receives).toHaveLength(1);
+          expect(service.receives).toEqual([{ id: 'somecoolreceivedmessage', version: '1.0.0' }]);
         });
 
         it('if the service is already defined and is receiving messages these are persisted', async () => {


### PR DESCRIPTION
## Motivation
Considering the sends and received messages for asyncapi v2.x

The generator adds the sent and received message to a service this works well for Asyncapi v3 but for Asyncapi v2.x there is a lack of considering operation action == subscribe to let the message be considered as a received message. 

The PR adds this possibility and adds the unit tests to validate a simple v2 spec 