### PR TITLE
feat[(channels]): avoid creating channel if not explicitly owned by s…

### DIFF
--- a/src/test/asyncapi-files/streetlights-kafka-asyncapi.yml
+++ b/src/test/asyncapi-files/streetlights-kafka-asyncapi.yml
@@ -73,6 +73,17 @@ channels:
     messages:
       dimLight:
         $ref: '#/components/messages/dimLight'
+  streetTrafic:
+    x-eventcatalog-channel-version: 2.0.0
+    messages:
+      blockedByTrafic:
+        $ref: '#/components/messages/blockedByTrafic'
+  trafickLightMaintanance:
+    x-eventcatalog-channel-version: 2.0.0
+    x-eventcatalog-role: client
+    messages:
+      traficLightBroken:
+        $ref: '#/components/messages/traficLightBroken'
 operations:
   receiveLightMeasurement:
     action: receive
@@ -138,6 +149,17 @@ components:
         - $ref: '#/components/messageTraits/commonHeaders'
       payload:
         $ref: '#/components/schemas/dimLightPayload'
+    blockedByTrafic:
+      name: blockedByTrafic
+      title: Street Blocked By Trafic
+      x-eventcatalog-role: client
+    traficLightBroken:
+      name: traficLightBroken
+      title: Street Trafic Light Broken
+      payload:
+        sendAt:
+          $ref: '#/components/schemas/sentAt'
+
   schemas:
     lightMeasuredPayload:
       type: object

--- a/src/test/plugin.test.ts
+++ b/src/test/plugin.test.ts
@@ -1002,6 +1002,19 @@ describe('AsyncAPI EventCatalog Plugin', () => {
           expect(versionedChannel).toBeDefined();
           expect(newChannel).toBeDefined();
         });
+
+        it('if the channel messages are not owned by service dont create channel', async () => {
+          const { getChannel } = utils(catalogDir);
+
+          await plugin(config, {
+            services: [{ path: join(asyncAPIExamplesDir, 'streetlights-kafka-asyncapi.yml'), id: 'streetlights-service' }],
+            parseChannels: true,
+          });
+
+          const channel = await getChannel('streetTrafic');
+
+          expect(channel).not.toBeDefined();
+        });
       });
     });
 


### PR DESCRIPTION
avoid creating channel if not explicitly owned by service or all messages not owned

## Motivation
Creating channels that are present in the original service breaks the original channel page. to avoid inconsistency, we apply the same ownership concept presented or messages for channels

Note: Documentation will be refined if PR validated 